### PR TITLE
quick-fix to enable proper detection of Novatek 9666x MP4 files (i.e. Viofo A119/A119S/A119V3)

### DIFF
--- a/ts_processor.py
+++ b/ts_processor.py
@@ -188,7 +188,7 @@ def detect_file_type(input_file):
                                         model = "unknown"
                                         break
                             offset += inp.end
-                    if box.type.decode("utf-8") == "gps": #has Novatek-specific stuff
+                    if box.type.decode("utf-8") == "moov": #has Novatek-specific stuff
                         fx.seek(0)
                         largeelem = fx.read()
                         startbytes = [m.start() for m in re.finditer(b'freeGPS', largeelem)]


### PR DESCRIPTION
nested atoms(boxes) search is not working, so check condition is adjusted to from 'gps' to 'moov' and additional condition if non-empty  freeGPS packets exist