### PR TITLE
Add support for Viofo A119S with firmware 4.0.

### DIFF
--- a/ts_processor.py
+++ b/ts_processor.py
@@ -326,6 +326,9 @@ def get_gps_data_nt (input_ts_file, device):
         for startbyte in startbytes:
             currentdata = {}
             input_packet = largeelem[startbyte+2:startbyte+188]
+            if int.from_bytes(input_packet[10:14], byteorder='little') == 0:
+                # Viofo A119S seems to put the data somewhere else...
+                input_packet = input_packet[32:]
             bs = list(input_packet)
             hour = int.from_bytes(input_packet[10:14], byteorder='little')
             minute = int.from_bytes(input_packet[14:18], byteorder='little')


### PR DESCRIPTION
The .ts files generated by the A119S with the most recent firmware (v4.0) seem to put the GPS information at a different location in the packet that doesn't correspond with either the A119 V3 or Blueskysea B4K; this pull request adds code to handle the different offset.